### PR TITLE
Read AWS config file for region information 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,7 @@ Koala Shield requires Go 1.15 or higher. As a prerequisite please [download and 
    ```sh
    go get github.com/koala-labs/koala-shield
    ```
-2. Set your [AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config) and make sure to export your desired AWS region.
-   ```sh
-   export AWS_REGION=region
-   ```
+2. Set your [AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config) and make sure to export your desired AWS region in the AWS config file.
 
 <!-- USAGE EXAMPLES -->
 

--- a/cmd/block.go
+++ b/cmd/block.go
@@ -31,13 +31,7 @@ var blockCmd = &cobra.Command{
 	Use:   "block",
 	Short: "Block all the prefixes owned by an ASN using an AWS WAF IP list",
 	Run: func(cmd *cobra.Command, args []string) {
-		region, err := cmd.Flags().GetString("aws-region")
-		if err != nil {
-			fmt.Println(aurora.Red(err))
-			os.Exit(1)
-		}
-
-		s := shield.NewShield(region)
+		s := shield.NewShield()
 
 		for _, asn := range args {
 			err := s.CreateBlockList(asn)

--- a/cmd/ipsets.go
+++ b/cmd/ipsets.go
@@ -31,13 +31,8 @@ var ipsetsCmd = &cobra.Command{
 	Use:   "ipsets",
 	Short: "List all IP sets registered in AWS WAF",
 	Run: func(cmd *cobra.Command, args []string) {
-		region, err := cmd.Flags().GetString("aws-region")
-		if err != nil {
-			fmt.Println(aurora.Red(err))
-			os.Exit(1)
-		}
 
-		s := shield.NewShield(region)
+		s := shield.NewShield()
 
 		t := table.NewWriter()
 		t.SetOutputMirror(os.Stdout)

--- a/cmd/lookup.go
+++ b/cmd/lookup.go
@@ -32,12 +32,7 @@ var lookupCmd = &cobra.Command{
 	Use:   "lookup",
 	Short: "Lookup information about IP addresses and ASN numbers",
 	Run: func(cmd *cobra.Command, args []string) {
-		region, err := cmd.Flags().GetString("aws-region")
-		if err != nil {
-			fmt.Println(aurora.Red(err))
-			os.Exit(1)
-		}
-		s := shield.NewShield(region)
+		s := shield.NewShield()
 
 		output := []table.Row{}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,7 +63,6 @@ func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
-	rootCmd.PersistentFlags().String("aws-region", viper.GetString("aws-region"), "AWS Region")
 }
 
 // initConfig reads in ENV variables if set.

--- a/cmd/unBlock.go
+++ b/cmd/unBlock.go
@@ -31,13 +31,7 @@ var unBlockCmd = &cobra.Command{
 	Use:   "un-block",
 	Short: "Un-block an ASN by removing their IP Set from WAF Rules",
 	Run: func(cmd *cobra.Command, args []string) {
-		region, err := cmd.Flags().GetString("aws-region")
-		if err != nil {
-			fmt.Println(aurora.Red(err))
-			os.Exit(1)
-		}
-
-		s := shield.NewShield(region)
+		s := shield.NewShield()
 
 		for _, asn := range args {
 			err := s.DisableBlockList(asn)

--- a/shield/awswaf.go
+++ b/shield/awswaf.go
@@ -48,9 +48,9 @@ type awsWAFClient struct {
 }
 
 // newWAFClient creates a new client and loads the default AWS config
-func newWAFClient(region string) *awsWAFClient {
-	session := session.Must(session.NewSession(&aws.Config{
-		Region: aws.String(region),
+func newWAFClient() *awsWAFClient {
+	session := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
 	}))
 	return &awsWAFClient{
 		waf: wafregional.New(session),

--- a/shield/shield.go
+++ b/shield/shield.go
@@ -31,8 +31,8 @@ type Shield struct {
 }
 
 // NewShield creates a new client and loads the default AWS config
-func NewShield(region string) *Shield {
-	waf := newWAFClient(region)
+func NewShield() *Shield {
+	waf := newWAFClient()
 
 	bpg := newLookupClient()
 	return &Shield{

--- a/shield/shield_test.go
+++ b/shield/shield_test.go
@@ -163,7 +163,7 @@ func (c *mockLookupErrorClient) asnPrefixesLookup(asn string) (*asnPrefixesLooku
 
 // TESTS
 func TestNewShield(t *testing.T) {
-	shield := NewShield("us-east-1")
+	shield := NewShield()
 
 	if shield.waf == nil {
 		t.Errorf("TestNewShield did not initialize waf attribute correctly")


### PR DESCRIPTION
# What

Read the AWS region from the AWS config file (`~/.aws/config`) instead of relying on a CLI flag or an ENV variable

# Why

Reading the region from the config matches how the AWS credentials are read and streamlines initializing the AWS SDK session

# How

The [AWS SDK](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html) makes it really easy to read the config file
